### PR TITLE
Dependency updates to remediate GCP-related security issues

### DIFF
--- a/connectors/riot-file/riot-file.gradle
+++ b/connectors/riot-file/riot-file.gradle
@@ -20,7 +20,7 @@ dependencies {
     implementation 'org.springframework:spring-oxm'
     implementation group: 'org.springframework.cloud', name: 'spring-cloud-aws-context', version: awsVersion
     implementation group: 'org.springframework.cloud', name: 'spring-cloud-aws-autoconfigure', version: awsVersion
-    implementation(group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-storage', version: gcpVersion) {
+    implementation(group: 'com.google.cloud', name: 'spring-cloud-gcp-starter-storage', version: gcpVersion) {
         exclude group: 'javax.annotation', module: 'javax.annotation-api'
     }
     testImplementation group: 'com.redis', name: 'spring-batch-redis', version: springBatchRedisVersion, classifier: 'tests'

--- a/connectors/riot-file/src/main/java/com/redis/riot/file/FileUtils.java
+++ b/connectors/riot-file/src/main/java/com/redis/riot/file/FileUtils.java
@@ -25,10 +25,10 @@ import org.springframework.batch.item.file.mapping.JsonLineMapper;
 import org.springframework.batch.item.json.JacksonJsonObjectReader;
 import org.springframework.batch.item.json.JsonItemReader;
 import org.springframework.batch.item.json.builder.JsonItemReaderBuilder;
-import org.springframework.cloud.gcp.autoconfigure.storage.GcpStorageAutoConfiguration;
-import org.springframework.cloud.gcp.core.GcpScope;
-import org.springframework.cloud.gcp.core.UserAgentHeaderProvider;
-import org.springframework.cloud.gcp.storage.GoogleStorageResource;
+import com.google.cloud.spring.autoconfigure.storage.GcpStorageAutoConfiguration;
+import com.google.cloud.spring.core.GcpScope;
+import com.google.cloud.spring.core.UserAgentHeaderProvider;
+import com.google.cloud.spring.storage.GoogleStorageResource;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
@@ -68,7 +68,7 @@ public abstract class FileUtils {
 	}
 
 	/**
-	 * 
+	 *
 	 * @param filename Filename that might include a glob pattern
 	 * @return List of file
 	 * @throws IOException

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,7 @@ kordampPluginVersion        = 0.54.0
 
 awsVersion                  = 2.2.6.RELEASE
 datafakerVersion            = 2.1.0
-gcpVersion                  = 1.2.8.RELEASE
+gcpVersion                  = 5.1.2
 jdksPluginVersion           = 1.5.1
 latencyutilsVersion         = 2.0.3
 lettucemodVersion           = 3.7.3


### PR DESCRIPTION
This PR updates the GCP library to the latest available (5.1.2) and that is recommended for use with Spring Boot 3.2.x.  It resolves the `guava` vulnerability present in 1.2.8 but not the protobuf or oauth dependencies.  Will submit a follow-up PR for those shortly.