### PR TITLE
add parseHex and parseUuid spel functions to return byte arrays

### DIFF
--- a/docs/guide/src/docs/asciidoc/import.adoc
+++ b/docs/guide/src/docs/asciidoc/import.adoc
@@ -30,6 +30,10 @@ The `replicate` command exposes 2 command objects named `source` and `target`.
 
 `geo`:: Convenience function that takes a longitude and a latitude to produce a RediSearch geo-location string in the form `longitude,latitude` (e.g. `location=#geo(lon,lat)`)
 
+`parseHex`:: Parse a hexadecimal string to a byte array.
+
+`parseUuid`:: Parse a UUID string to a byte array.
+
 .Processor example
 [source,console]
 ----

--- a/plugins/riot/src/main/java/com/redis/riot/EvaluationContextArgs.java
+++ b/plugins/riot/src/main/java/com/redis/riot/EvaluationContextArgs.java
@@ -24,6 +24,8 @@ public class EvaluationContextArgs {
 	public static final String VAR_DATE = "date";
 	public static final String VAR_NUMBER = "number";
 	public static final String VAR_FAKER = "faker";
+	public static final String PARSE_HEX = "parseHex";
+	public static final String PARSE_UUID = "parseUuid";
 
 	@Option(arity = "1..*", names = "--var", description = "SpEL expressions for context variables, in the form var=\"exp\". For details see https://docs.spring.io/spring-framework/reference/core/expressions.html", paramLabel = "<v=exp>")
 	private Map<String, Expression> varExpressions = new LinkedHashMap<>();
@@ -39,6 +41,9 @@ public class EvaluationContextArgs {
 	public StandardEvaluationContext evaluationContext() {
 		StandardEvaluationContext context = new StandardEvaluationContext();
 		RiotUtils.registerFunction(context, "geo", GeoLocation.class, "toString", String.class, String.class);
+		RiotUtils.registerFunction(context, PARSE_HEX, SpelUtils.class, "parseHex", String.class);
+		RiotUtils.registerFunction(context, PARSE_UUID, SpelUtils.class, "parseUuid", String.class);
+
 		context.setVariable(VAR_DATE, new SimpleDateFormat(dateFormat));
 		context.setVariable(VAR_NUMBER, new DecimalFormat(numberFormat));
 		context.setVariable(VAR_FAKER, new Faker());

--- a/plugins/riot/src/main/java/com/redis/riot/SpelUtils.java
+++ b/plugins/riot/src/main/java/com/redis/riot/SpelUtils.java
@@ -1,0 +1,37 @@
+package com.redis.riot;
+
+public class SpelUtils {
+
+    public static String parseHex(String hexVal) {
+        if (hexVal == null) {
+            return null;
+        }
+        if (hexVal.startsWith("0x")) {
+            hexVal = hexVal.substring(2);
+        }
+        byte[] bytes = new byte[hexVal.length() / 2];
+        for (int i = 0; i < bytes.length; i++) {
+            byte b = (byte) Integer.parseInt(hexVal.substring(2 * i, 2 * i + 2), 16);
+            bytes[i] = b;
+        }
+
+        return new String(bytes);
+    }
+
+    public static String parseUuid(String uuid) {
+        if (uuid == null) {
+            return null;
+        }
+
+        java.util.UUID uuidObj = java.util.UUID.fromString(uuid);
+        byte[] bytes = new byte[16];
+        long msb = uuidObj.getMostSignificantBits();
+        long lsb = uuidObj.getLeastSignificantBits();
+        for (int i = 0; i < 8; i++) {
+            bytes[i] = (byte) (msb >>> (8 * (7 - i)));
+            bytes[8 + i] = (byte) (lsb >>> (8 * (7 - i)));
+        }
+
+        return new String(bytes);
+    }
+}


### PR DESCRIPTION
Added new spel functions `parseHex` and `parseUuid`

To complete before merge:
- [x] test locally with local redis instance
- [ ] add unit/integration tests